### PR TITLE
fix: Update readme to lockfile compatible setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # Document Web UI
 
-[![Build Status](https://travis-ci.org/GovTechSG/document-web-ui.svg?branch=master)](https://travis-ci.org/GovTechSG/document-web-ui)
-
 See also:
 
-* [document-schema](https://github.com/GovTechSG/document-schema)
-* [document-contract](https://github.com/GovTechSG/document-contract)
-* [document-cli](https://github.com/GovTechSG/document-cli)
+* [Tradetrust Schemas](https://github.com/TradeTrust/tradetrust-schema)
+* [Document Store Ethereum Smart Contract](https://github.com/Open-Attestation/document-store-contract)
+* [ERC 721](http://erc721.org/)
+* [Tradetrust CLI Tool](https://github.com/TradeTrust/tradetrust-cli)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ See also:
 ## Development
 
 ```bash
-yarn
-yarn dev
-yarn lint
+npm
+npm dev
+npm lint
 
-yarn start # serves the ui
+npm run start # serves the ui
 ```
 
 ### Setting up web3

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See also:
 ## Development
 
 ```bash
-npm
+npm install
 npm run dev
 npm run lint
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ See also:
 
 ```bash
 npm
-npm dev
-npm lint
+npm run dev
+npm run lint
 
 npm run start # serves the ui
 ```


### PR DESCRIPTION
The project publishes a `package-lock.json` file, not a yarn.lock file; installing via `yarn` results in incompatible package versions and consequently a broken build. Using `npm` results in the correct versions being installed due to the lockfile being present.
This small documentation change will save future contributors time in debugging the issue.